### PR TITLE
Add option to dromedary.py to generate Opam switch and install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,31 @@ All scripts display a help screen showing all possible arguments by adding `-h` 
 
 #### dromedary.py
 
+You can use `dromedary.py` to generate an opam switch or use an existing one.
+
+Running `python3 dromedary.py -o BUCK_PATH JSON_CONFIG` will use the JSON configuration file `JSON_CONFIG` to generate a new Opam switch and install the configured packages. The Buck 2 file `BUCK_PATH` is generated from the packages of the generated switch.
+
 Running `python3 dromedary.py -s SWITCH_NAME -o BUCK_PATH` will parse the Opam switch `SWITCH_NAME` for package information and create a BUCK file at `BUCK_PATH`. If no `-s SWITCH_NAME` is given, the currently active one is used. To exclude packages from `BUCK_PATH`, use `-e` with a space separated list of package names: `python3 dromedary.py -s SWITCH_NAME -o BUCK_PATH -e ocaml_lsp_server ocamlformat` does not include the packages `ocaml_lsp_server` and `ocamlformat`.
+
+JSON configuration:
+
+See file [./dromedary_example.json](./dromedary_example.json).
+
+```json
+{
+    "name": "./third-party",
+    "compiler": "ocaml-base-compiler",
+    "packages": [
+        "menhirLib",
+        "sedlex=3.2",
+        "alcotest>=1.7.0"
+    ]
+}
+```
+
+- `name` - Either the path to the directory to generate the Opam switch in or the global name of the switch. The path is relative to the directory of the JSON file. If this is missing, `"./"` is used.
+- `compiler` - The compiler to use for the switch. If this is missing, `"ocaml-variants"` is used.
+- `packages` - An array of Opam packages to install, may contain version numbers, each string is passed verbatim to `opam install`. _Must_ be present.
 
 **Note**: `dromedary.py` internally uses the scripts `meta2json.py` and `rules.py`, so no need to call them separately.
 

--- a/dromedary.py
+++ b/dromedary.py
@@ -204,7 +204,10 @@ def run_cmd_output(cmd_args: List[Any], cmd_env: Optional[Dict[str, str]]) -> No
     )  # nosec
 
     if proc.returncode != 0:
-        print(f"Error: command '{proc.args}' returned '{proc.returncode}'")
+        print(
+            f"Error: command '{proc.args}' returned '{proc.returncode}'",
+            file=sys.stderr,
+        )
         return error_exit(6)
 
 
@@ -263,10 +266,10 @@ def read_json(path: str) -> Dict[str, Any]:
         )
         return error_exit(4)
     except json.decoder.JSONDecodeError as exc:
-        print(f"Error: file '{path}' JSON parsing error:\n{exc}")
+        print(f"Error: file '{path}' JSON parsing error:\n{exc}", file=sys.stderr)
         return error_exit(5)
     except Exception as exc:
-        print(f"Error: exception caught:\n{exc}")
+        print(f"Error: exception caught:\n{exc}", file=sys.stderr)
         return error_exit(6)
 
     return switch_config
@@ -287,7 +290,8 @@ def validate_config(switch_config: Dict[str, Any], json_path: str) -> SwitchConf
     switch_packages = switch_config.get("packages")
     if switch_packages is None:
         print(
-            "Error: no packages to install found in JSON configuration. Array 'packages' is missing!"
+            "Error: no packages to install found in JSON configuration. Array 'packages' is missing!",
+            file=sys.stderr,
         )
         return error_exit(8)
 

--- a/dromedary_example.json
+++ b/dromedary_example.json
@@ -1,0 +1,9 @@
+{
+    "name": "./third-party",
+    "compiler": "ocaml-variants",
+    "packages": [
+        "menhirLib",
+        "sedlex=3.2",
+        "alcotest>=1.7.0"
+    ]
+}


### PR DESCRIPTION
Add the possibility to create a new Opam switch at a given path or with a given name, setting its compiler and install packages in this newly created switch. This Opam switch's packages are used to generate the `BUCK` file.

Example configuration:

```json
{
    "name": "./third-party",
    "compiler": "ocaml-variants",
    "packages": [
        "menhirLib",
        "sedlex=3.2",
        "alcotest>=1.7.0"
    ]
}
```