### PR TITLE
rules.py: Correctly include otherlib C libraries

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -218,30 +218,37 @@ def _process(rules, opam_switch, pkg):
     # check if the library is present on disk as it might be
     # an external dependency like libpng or z
     # vsiles:
-    # In <= 4.14.0, the content of the threads/posix library is not correctly
-    # installed: all the cm* files are in ocaml/threads/ but the lib*.a files
-    # are in ocaml/ directly, so we need to patch that manually.
+    # In <= 4.14.0, the content of several libraries, including
+    # threads/posix, unix, and runtime_events, are not correctly
+    # installed: all the cm* files are in ocaml/<lib>/ but the
+    # lib*.a files are in ocaml/ directly, so we need to patch
+    # that manually.
     #
     # TODO: revisit in 5.0 in case it's better
     ocaml = os.path.join(relativelib, "ocaml")
+    otherlibs = [
+        "dynlink",
+        "runtime_events",
+        "str",
+        "threads",
+        "unix",
+    ]
 
     native_c_libs = []
     for lib in pkg["native_c_libs"]:
-        patched_dir = target_dir
-        if name.startswith("threads."):  # . is important. Matches .posix and .vm
-            patched_dir = ocaml
         lib_name = "lib{}.a".format(lib)
-        lib_path = check_file(opam_switch, patched_dir, lib_name)
+        lib_path = check_file(opam_switch, target_dir, lib_name)
+        if lib in otherlibs and not lib_path:
+            lib_path = check_file(opam_switch, ocaml, lib_name)
         if lib_path:
             native_c_libs.append(lib_path)
 
     bytecode_c_libs = []
     for lib in pkg["bytecode_c_libs"]:
-        patched_dir = target_dir
-        if name.startswith("threads."):  # . is important. Matches .posix and .vm
-            patched_dir = ocaml
         lib_name = "lib{}.a".format(lib)
-        lib_path = check_file(opam_switch, patched_dir, lib_name)
+        lib_path = check_file(opam_switch, target_dir, lib_name)
+        if lib in otherlibs and not lib_path:
+            lib_path = check_file(opam_switch, ocaml, lib_name)
         if lib_path:
             bytecode_c_libs.append(lib_path)
 

--- a/rules.py
+++ b/rules.py
@@ -224,7 +224,7 @@ def _process(rules, opam_switch, pkg):
     # lib*.a files are in ocaml/ directly, so we need to patch
     # that manually.
     #
-    # TODO: revisit in 5.0 in case it's better
+    # TODO: revisit in 5.1 in case it's better
     ocaml = os.path.join(relativelib, "ocaml")
     otherlibs = [
         "dynlink",


### PR DESCRIPTION
From what I can glean of the `.opam/default/lib/ocaml` directory on my 5.0.0 install, there are several "otherlib" libraries that are included, and have their own subdirectories, but have their C `.a` files instead in the `ocaml/` folder. 

I noticed there was some special logic for finding `libthreads.a`, but not for finding, e.g. `libunix.a`. This caused some undefined references in a project I was experimenting with. I figure all of these "otherlibs" (as they're called, see: `rg ~/.opam/default/lib/ocaml`) should be subject to the patched directory logic.

In the process, I removed `threads.` (with a period) from the list, because it seems like on 5.0.0 `threads.vm` and `threads.posix` do not directly reference the C library, and I assume because they reference `:threads` in the generated BUCK file, that they will pick up the library transitively. Feel free to push back on this though if there's some behavior in OCaml <=4.14 that requires this.

### Testing

I've tested this only insofar as it has helped me resolve an issue compiling a project that references `:unix`, and I am assuming that the behavior is similar for other projects. Happy to do more extensive testing if requested.