### PR TITLE
: fix README build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ocaml-scripts [![facebook](https://circleci.com/gh/facebook/ocaml-scripts.svg?style=svg)](https://app.circleci.com/pipelines/github/facebook/ocaml-scripts)
+# ocaml-scripts [![Run tests](https://github.com/facebook/ocaml-scripts/actions/workflows/run-tests.yml/badge.svg)](https://github.com/facebook/ocaml-scripts/actions/workflows/run-tests.yml)
 
 Experimental scripts to build a BUCK/TARGETS file from an opam switch.
 Forwords: this is Python, for now, because we hope to reuse most of this experiment to


### PR DESCRIPTION
Summary: the README status badge was still pointing at CircleCI

Differential Revision:
D54306041

Privacy Context Container: L1124100


